### PR TITLE
Postlab 4: Number of ones

### DIFF
--- a/labs/lab04/index.html
+++ b/labs/lab04/index.html
@@ -279,7 +279,7 @@ char CharArray2D[6][5];</code></pre>
 <pre><code>int main (int argc, char **argv)</code></pre>
 <p>These two parameters are providing you with the command-line parameters. The first parameter, <code>argc</code>, is the number of parameters plus one. The second parameter, <code>argv</code>, is an array of C-style strings (some people list the type as <code>char *argv[]</code> to make this more clear -- either way is fine).</p>
 <p>Thus, if you supply the program with 3 command-line parameters, then argc would be set to 4, <code>argv[0]</code> would be the C-string that contains the program name ('a.out', for example'), and <code>argv[1]</code>, <code>argv[2]</code>, and <code>argv[3]</code> are the 3 supplied command line parameters.</p>
-<p>Your task is to implement the binary bit counter function that takes in a single command-line value (which is a standard base-10 integer) and prints out the number of bits contained therein.</p>
+<p>Your task is to implement the binary bit counter function that takes in a single command-line value (which is a standard base-10 integer) and prints out the number of ones contained therein.</p>
 <h3 id="converting-between-number-systems">Converting between number systems</h3>
 <p>Complete and submit the <a href="radixWorksheet.doc" class="uri">radixWorksheet.doc</a> file as a PDF file called radixWorksheet.pdf. It must be in PDF format! See <a href="../../docs/convert_to_pdf.html">How To Convert A File To PDF</a> for details.</p>
 </body>

--- a/labs/lab04/index.md
+++ b/labs/lab04/index.md
@@ -282,7 +282,7 @@ These two parameters are providing you with the command-line parameters.  The fi
 
 Thus, if you supply the program with 3 command-line parameters, then argc would be set to 4, `argv[0]` would be the C-string that contains the program name ('a.out', for example'), and `argv[1]`, `argv[2]`, and `argv[3]` are the 3 supplied command line parameters.
 
-Your task is to implement the binary bit counter function that takes in a single command-line value (which is a standard base-10 integer) and prints out the number of bits contained therein.
+Your task is to implement the binary bit counter function that takes in a single command-line value (which is a standard base-10 integer) and prints out the number of ones contained therein.
 
 ### Converting between number systems ###
 


### PR DESCRIPTION
Changed "number of bits" to "number of ones" in the post-lab to fix a contradiction that has caused confusion in past semesters. 