### PR TITLE
change "test(&test)" to "test(const test&)" in cpptest.cpp

### DIFF
--- a/slides/01-cpp.html
+++ b/slides/01-cpp.html
@@ -1599,7 +1599,7 @@ test::~test() {
 Source code: [cpptest.cpp](code/01-cpp/cpptest.cpp.html) ([src](code/01-cpp/cpptest.cpp))
 ```
 test::test(const test& x) : id(x.id), value(x.value) {
-    cout << "calling test(&test) on " << *this 
+    cout << "calling test(const test&) on " << *this 
          << "; address is " << this << endl;
 }
 
@@ -1724,7 +1724,7 @@ cout << "finished invoking subroutine..." << endl;
 // output:
 // ---------------------------------------
 // about to invoke subroutine...
-// calling test(&test) on test[id=2,v=2]; 
+// calling test(const test&) on test[id=2,v=2]; 
 //                   address is 0xff852a38
 // calling test(10); object created is test[id=4,v=10]; 
 //                   address is 0xff852a40
@@ -1745,7 +1745,7 @@ test f = b;
 
 // output:
 // ---------------------------------------
-// calling test(&test) on test[id=1,v=1]; 
+// calling test(const test&) on test[id=1,v=1]; 
 //                     address is 0xff852a30
 ```
 </script></section>
@@ -1784,7 +1784,7 @@ aa = b;
 // ---------------------------------------
 // assignment...
 // calling operator=(test[id=1,v=1])
-// calling test(&test) on test[id=1,v=1]; 
+// calling test(const test&) on test[id=1,v=1]; 
 //                     address is 0xa009008
 ```
 </script></section>

--- a/slides/code/01-cpp/cpptest.cpp
+++ b/slides/code/01-cpp/cpptest.cpp
@@ -49,7 +49,7 @@ test::test(int v) : id (idcount++), value(v) {
 }
 
 test::test(const test& x) : id(x.id), value(x.value) {
-    cout << "calling test(&test) on " << *this << "; address is " << this << endl;
+    cout << "calling test(const test&) on " << *this << "; address is " << this << endl;
 }
 
 test::~test() {
@@ -133,7 +133,7 @@ int main() {
     // output:
     // ----------------------------------------
     // about to invoke subroutine...
-    // calling test(&test) on test[id=2,v=2]; address is 0xff852a38
+    // calling test(const test&) on test[id=2,v=2]; address is 0xff852a38
     // calling test(10); object created is test[id=4,v=10]; address is 0xff852a40
     // calling ~test() on test[id=2,v=2]
     // finished invoking subroutine...

--- a/slides/code/01-cpp/cpptest.cpp.html
+++ b/slides/code/01-cpp/cpptest.cpp.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<meta name="GENERATOR" content="GNU source-highlight 3.1.5
+<meta name="GENERATOR" content="GNU source-highlight 3.1.8
 by Lorenzo Bettini
 http://www.lorenzobettini.it
 http://www.gnu.org/software/src-highlite">
@@ -60,7 +60,7 @@ test<font color="#990000">::</font><b><font color="#000000">test</font></b><font
 <font color="#FF0000">}</font>
 
 test<font color="#990000">::</font><b><font color="#000000">test</font></b><font color="#990000">(</font><b><font color="#0000FF">const</font></b> test<font color="#990000">&amp;</font> x<font color="#990000">)</font> <font color="#990000">:</font> <b><font color="#000000">id</font></b><font color="#990000">(</font>x<font color="#990000">.</font>id<font color="#990000">),</font> <b><font color="#000000">value</font></b><font color="#990000">(</font>x<font color="#990000">.</font>value<font color="#990000">)</font> <font color="#FF0000">{</font>
-    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling test(&amp;test) on "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"; address is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
+    cout <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"calling test(const test&amp;) on "</font> <font color="#990000">&lt;&lt;</font> <font color="#990000">*</font><b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> <font color="#FF0000">"; address is "</font> <font color="#990000">&lt;&lt;</font> <b><font color="#0000FF">this</font></b> <font color="#990000">&lt;&lt;</font> endl<font color="#990000">;</font>
 <font color="#FF0000">}</font>
 
 test<font color="#990000">::~</font><b><font color="#000000">test</font></b><font color="#990000">()</font> <font color="#FF0000">{</font>
@@ -144,7 +144,7 @@ ostream<font color="#990000">&amp;</font> <b><font color="#0000FF">operator</fon
     <i><font color="#9A1900">// output:</font></i>
     <i><font color="#9A1900">// ----------------------------------------</font></i>
     <i><font color="#9A1900">// about to invoke subroutine...</font></i>
-    <i><font color="#9A1900">// calling test(&amp;test) on test[id=2,v=2]; address is 0xff852a38</font></i>
+    <i><font color="#9A1900">// calling test(const test&amp;) on test[id=2,v=2]; address is 0xff852a38</font></i>
     <i><font color="#9A1900">// calling test(10); object created is test[id=4,v=10]; address is 0xff852a40</font></i>
     <i><font color="#9A1900">// calling ~test() on test[id=2,v=2]</font></i>
     <i><font color="#9A1900">// finished invoking subroutine...</font></i>


### PR DESCRIPTION
cpptest.cpp uses "test(&test)" in its output to reference the copy-constructor of test; this changes it to use "test(const test&)" and updates the HTML slides accordingly.