### PR TITLE
Fix broken/outdated link for AVL tree animation in slides index

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -44,7 +44,7 @@
 <p><a href="05-trees.html#/">Slide set 5: Trees</a> (<a href="reiss/trees.pdf">version from Reiss's lectures (PDF)</a>)</p>
 <ul>
 <li>The trees diagrams were generated from the files described <a href="graphs/index.html">here</a></li>
-<li>The tree animation site is <a href="http://www.qmatica.com/DataStructures/Trees/BST.html">here</a> (<a href="http://webdiis.unizar.es/asignaturas/EDA/AVLTree/avltree.html">mirror</a>)</li>
+<li>The tree animation site is <a href="https://www.cs.usfca.edu/~galles/visualization/AVLtree.html">here</a></li>
 </ul>
 <p><a href="06-hashes.html#/">Slide set 6: Hashes</a></p>
 <ul>

--- a/slides/index.md
+++ b/slides/index.md
@@ -39,7 +39,7 @@ Program and Data Representation: Slides
 [Slide set 5: Trees](05-trees.html#/) ([version from Reiss's lectures (PDF)](reiss/trees.pdf))
 
 - The trees diagrams were generated from the files described [here](graphs/index.html)
-- The tree animation site is [here](http://www.qmatica.com/DataStructures/Trees/BST.html) ([mirror](http://webdiis.unizar.es/asignaturas/EDA/AVLTree/avltree.html))
+- The tree animation site is [here](https://www.cs.usfca.edu/~galles/visualization/AVLtree.html)
 
 [Slide set 6: Hashes](06-hashes.html#/)
 


### PR DESCRIPTION
A fix to issue #48 